### PR TITLE
Log Public URL for nuxi

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -51,6 +51,7 @@ const nuxtModule: Module<ModuleOptions> = function(moduleOptions) {
     url = await ngrok.connect({ ...options, addr } as INgrokOptions)
 
     nuxt.options.publicRuntimeConfig.ngrok = { url }
+    console.success(`Public URL: ${chalk2.underline.yellow(url)}`)
     nuxt.options.cli.badgeMessages.push(
       `Public URL: ${chalk.underline.yellow(url)}`
     )


### PR DESCRIPTION
Nuxi does not use nuxt.options.cli.badgeMessages. This simple enhancement will log the Public URL for nuxt-edge developers